### PR TITLE
[FIX] 카드 생성 시 고정 명함 바로 뒤에 생성토록 수정

### DIFF
--- a/src/main/java/com/nada/server/domain/Card.java
+++ b/src/main/java/com/nada/server/domain/Card.java
@@ -73,7 +73,7 @@ public class Card implements Persistable<String> {
 
         // card Id 랜덤 UUID 이용한 랜덤생성
         String cardId = UUID.randomUUID().toString().replaceAll("-", ""); // -를 제거해 주었다.
-        cardId = cardId.substring(0, 10).toUpperCase();
+        cardId = cardId.substring(0, 6).toUpperCase();
         card.setId(cardId);
         card.setBackground(background);
         card.setBirthDate(birthDate);

--- a/src/main/java/com/nada/server/repository/CardRepository.java
+++ b/src/main/java/com/nada/server/repository/CardRepository.java
@@ -6,14 +6,19 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface CardRepository extends JpaRepository<Card,String> {
     @Query("SELECT c FROM Card c JOIN FETCH c.user WHERE c.id=:id")
     Optional<Card> findById(@Param("id") String id);
-    @Query("SELECT MAX(priority) FROM Card")
-    Integer maxPriority();
+    @Query("SELECT MIN(c.priority) FROM Card c WHERE c.user.id=:userId")
+    Integer minPriority(@Param("userId") String userId);
+
+    @Modifying
+    @Query("UPDATE Card c SET c.priority = c.priority+1 WHERE c.priority > :minPriority")
+    void updatePriority(@Param("minPriority") Integer minPriority);
 
     @Query("SELECT c FROM Card c JOIN FETCH c.user WHERE c.user=:user")
     List<Card> findByUser(@Param("user")User user, Pageable pageable); // 유저의 카드 목록 조회 - 페이지네이션

--- a/src/main/java/com/nada/server/service/CardService.java
+++ b/src/main/java/com/nada/server/service/CardService.java
@@ -33,11 +33,12 @@ public class CardService {
     public String create(Card card, String userId){
         User user = userRepository.findById(userId).get();
 
-        Integer maxPriority = cardRepository.maxPriority();
-        if(maxPriority == null){
+        Integer minPriority = cardRepository.minPriority(userId);
+        if(minPriority == null){
             card.setPriority(Integer.valueOf(0));
         }else{
-            card.setPriority(maxPriority+1);
+            cardRepository.updatePriority(minPriority);
+            card.setPriority(minPriority+1);
         }
         card.setUser(user);
 


### PR DESCRIPTION
## 📌 변경 사항 및 이유
- 명함이 생성되면 맨 위 고정명함만 고정이고 그 아래 생성되어야함. 나머지는 우선순위 대로!
<!-- 변경한 내용과 그 이유를 적어주세요. -->

## 📌 참고 사항

<!-- 참고할 사항이 있다면 적어주세요. -->